### PR TITLE
Change filename hash method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,8 @@ class VersionHash {
     webpackConfig(webpackConfig) {
         let length = this.options.length
 
-        webpackConfig.output.filename = `[name].[hash:${length}].js`
-        webpackConfig.output.chunkFilename = `[name].[hash:${length}].js`
+        webpackConfig.output.filename = `[name].[chunkhash:${length}].js`
+        webpackConfig.output.chunkFilename = `[name].[chunkhash:${length}].js`
     }
 }
 


### PR DESCRIPTION
Updated the hash method to chunkhash. Allows extracted vendor and manifest files to have their own hash and not be updated if code in the main app is updated.