### PR TITLE
Fixed css filename path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const mix = require('laravel-mix')
 const forIn = require('lodash/forIn')
 const jsonfile = require('jsonfile')
 const removeHashFromKeyRegex = /\.(.+)\.(.+)$/g
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 class VersionHash {
     register(options = {}) {
@@ -36,13 +37,21 @@ class VersionHash {
         webpackConfig.output.filename = `[name].[chunkhash:${length}].js`
         webpackConfig.output.chunkFilename = `[name].[chunkhash:${length}].js`
 
+        let contenthash = `[contenthash:${length}].css`
+
         forIn(webpackConfig.plugins, (value, key) => {
 
             if (value instanceof ExtractTextPlugin) {
 
-                value.filename = `[name].[contenthash:${length}].css`
-                webpackConfig.plugins[key] = value;
+                if (!value.filename.includes(contenthash)) {
 
+                    let csspath = value.filename.substring(0, value.filename.lastIndexOf("."));
+                    let filename = `/${csspath}.[contenthash:${length}].css`    
+    
+                    if (value.filename != filename) {    
+                        value.filename = filename;    
+                    }
+                }
             }
             
         })


### PR DESCRIPTION
The [name] string prepends /js so it can’t be used. Grabbing the generated path from ExtractTextPlugin and adding the hash instead.