### PR TITLE
Option for delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# laravel-mix-versionHash
+# laravel-mix-versionhash
 
-[![npm](https://img.shields.io/npm/v/laravel-mix-versionhash.svg?style=for-the-badge)](https://www.npmjs.com/package/laravel-mix-versionhash) [![npm](https://img.shields.io/npm/dt/laravel-mix-versionhash.svg?style=for-the-badge)](https://www.npmjs.com/package/laravel-mix-versionhash)
+[![npm](https://img.shields.io/npm/v/laravel-mix-versionhash.svg)](https://www.npmjs.com/package/laravel-mix-versionhash) [![npm](https://img.shields.io/npm/dt/laravel-mix-versionhash.svg)](https://www.npmjs.com/package/laravel-mix-versionhash)
 
-auto append hash to file instead of using virtual one [Read More](https://github.com/JeffreyWay/laravel-mix/issues/1022)
+Auto append hash to file instead of using virtual one [Read More](https://github.com/JeffreyWay/laravel-mix/issues/1022)
 
 ## Installation
 
@@ -18,8 +18,9 @@ require('laravel-mix-versionhash')
 mix.versionHash();
 ```
 
-### Options
+## Options
 
-| option | type | default |      description       |
-|--------|------|---------|------------------------|
-| length | int  |    6    | the hash string length |
+| option    | type    | default      |      description                    |
+|-----------|---------|--------------|-------------------------------------|
+| length    | int     | `6`          | the hash string length              |
+| delimiter | string  | `'.'`        | the delimiter for filename and hash |


### PR DESCRIPTION
Great plugin! Much better than the query-based default.

I however prefer to use `-` as a delimiter (i.e. `app-652f21.js`) instead of the fixed `.`.

I've added the option to set your own delimiter:

```
mix.versionHash({
  length: 6,
  delimiter: '-'
});
```
The regex in play should be fully escaped to use any possible delimiter. Will also be backwards-compatible.

Hope this get merged. Thanks again!