### PR TITLE
bugfix: correct manifest filenames when using library code splitting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,8 @@ class VersionHash {
 
         webpackConfig.output.filename = chunkhash
 
-        if (webpackConfig.output.chunkFilename) {
+        let usesExtract = webpackConfig.optimization && webpackConfig.optimization.runtimeChunk
+        if (webpackConfig.output.chunkFilename && !usesExtract) {
             // merge chunkFilename paths
             let directory = path.dirname(webpackConfig.output.chunkFilename)
             webpackConfig.output.chunkFilename = `${directory}/${chunkhash}`


### PR DESCRIPTION
When using `.versionHash()` together with `.extract()` the filenames in the manifest file are prepended by `/./` paths which is incorrect (#17).

The cause of the error seems to be that the webpack config for the output filename must be different when running with or without extract. The path is required for the normal operation of versionhash without extract, but when using extract the path must not be included.