### PR TITLE
Sort the final manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "proxy-method": "^1.0.0"
     },
     "peerDependecies": {
-        "laravel-mix": "^2.0.0"
+        "laravel-mix": "^2.0.0",,
+        "collect.js": "^4.12.8"
     },
     "keywords": [
         "laravel",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const forIn = require('lodash/forIn')
 const escapeStringRegexp = require('escape-string-regexp')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const path = require('path')
+const collect = require('collect.js')
 const separator = '.'
 
 /**
@@ -212,7 +213,10 @@ class VersionHash {
                 newJson[key] = value
             })
 
-            file.write(newJson)
+            file.write(collect(newJson)
+                .sortKeys()
+                .all()
+            )
         })
 
         return this


### PR DESCRIPTION
In order to prevent subsequent runs from changing the manifest in ordering only, I have added a similar-to-mix sorting to the file output.