### PR TITLE
Fix: Prevents other plugins to tap on done hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ class VersionHash {
 
         return new class {
             apply(compiler) {
-                compiler.hooks.done.tapAsync('done', (stats) => {
+                compiler.hooks.done.tap('done', (stats) => {
                     forIn(stats.compilation.assets, (asset, path) => {
                         if (combinedFiles[path]) {
                             delete stats.compilation.assets[path]


### PR DESCRIPTION
It was using compiler.hooks.done.tapAsync to back slash to replace backslash with forward-slash. Because the function was not calling the callback for plugins chain to continue it was preventing other plugins from getting done hooks event.

As we are only doing synchronous work in that function I used compiler.hooks.done.tap instead.